### PR TITLE
fix: add missing extension LambdaCase

### DIFF
--- a/extend.cabal
+++ b/extend.cabal
@@ -47,6 +47,7 @@ library
                       , DerivingStrategies
                       , DuplicateRecordFields
                       , GeneralizedNewtypeDeriving
+                      , LambdaCase
                       , NamedFieldPuns
                       , OverloadedLists
                       , OverloadedStrings


### PR DESCRIPTION
This pull request makes a small change to the `extend.cabal` file by adding the `LambdaCase` language extension to the `library` section.