### PR TITLE
fix(nix): use extend-ai instead of extend for package name

### DIFF
--- a/extend.cabal
+++ b/extend.cabal
@@ -1,5 +1,5 @@
 cabal-version:      2.4
-name:               extend
+name:               extend-ai
 version:            1.0.0
 synopsis:           Servant bindings to Extend AI
 description:        This package provides comprehensive and type-safe bindings
@@ -63,7 +63,7 @@ test-suite tasty
     hs-source-dirs:   tasty
     main-is:          Main.hs
     build-depends:    base
-                    , extend
+                    , extend-ai
                     , tasty
                     , tasty-hunit
                     , text
@@ -79,7 +79,7 @@ executable extend-example
     hs-source-dirs:   extend-example
     main-is:          Main.hs
     build-depends:    base
-                    , extend
+                    , extend-ai
                     , text
                     , aeson
                     , servant-client


### PR DESCRIPTION
This pull request updates the package name in the `extend.cabal` file to `extend-ai` and ensures consistency in its usage across the file. The changes primarily affect the package name and its references in the test suite and executable sections.

### Package Name Update:
* Renamed the package from `extend` to `extend-ai` in the `name` field of `extend.cabal`.

### Dependency Updates:
* Updated the test suite (`tasty`) to replace the dependency on `extend` with `extend-ai`.
* Updated the executable (`extend-example`) to replace the dependency on `extend` with `extend-ai`.