### PR TITLE
chore: remove unused function

### DIFF
--- a/src/Extend/Prelude.hs
+++ b/src/Extend/Prelude.hs
@@ -44,9 +44,6 @@ module Extend.Prelude
     -- * API version
     ApiVersion (..),
     defaultApiVersion,
-
-    -- * Utilities
-    tshow,
   )
 where
 
@@ -127,7 +124,3 @@ newtype ApiVersion = ApiVersion {unApiVersion :: Text}
 -- | Default API version - 2025-04-21
 defaultApiVersion :: ApiVersion
 defaultApiVersion = ApiVersion "2025-04-21"
-
--- | Convert a value to its 'Text' representation
-tshow :: (Show a) => a -> Text
-tshow = pack . show


### PR DESCRIPTION
This pull request removes an unused utility function `tshow` from the `Extend.Prelude` module in the `src/Extend/Prelude.hs` file to clean up the codebase.

Code cleanup:

* Removed the `tshow` function, which converts a value to its `Text` representation, as it was no longer being used in the codebase. (`src/Extend/Prelude.hs`, [[1]](diffhunk://#diff-a1049c28f72e7af1e7493bc963691224134cf89c50ee85e3e71693f025a8a80dL47-L49) [[2]](diffhunk://#diff-a1049c28f72e7af1e7493bc963691224134cf89c50ee85e3e71693f025a8a80dL130-L133)