### PR TITLE
fix(workflows): avoid duplicated 'file' in attribute namespaces

### DIFF
--- a/extend-example/Main.hs
+++ b/extend-example/Main.hs
@@ -166,9 +166,9 @@ runCommand token version env = \case
                   then Prelude.error "Local file processing not implemented yet"
                   else
                     Workflows.ExtendFile
-                      { Workflows.extendFileFileName = maybeFileName,
-                        Workflows.extendFileFileUrl = Just f,
-                        Workflows.extendFileFileId = Nothing,
+                      { Workflows.extendFileName = maybeFileName,
+                        Workflows.extendFileUrl = Just f,
+                        Workflows.extendFileId = Nothing,
                         Workflows.extendFileOutputs = Nothing
                       }
             )

--- a/src/Extend/V1/Workflows.hs
+++ b/src/Extend/V1/Workflows.hs
@@ -617,11 +617,11 @@ instance ToJSON PredeterminedOutput where
 -- | File to process through a workflow
 data ExtendFile = ExtendFile
   { -- | The name of the file to be processed
-    extendFileFileName :: Maybe Text,
+    extendFileName :: Maybe Text,
     -- | A URL where the file can be downloaded from
-    extendFileFileUrl :: Maybe Text,
+    extendFileUrl :: Maybe Text,
     -- | Extend's internal ID for the file
-    extendFileFileId :: Maybe Text,
+    extendFileId :: Maybe Text,
     -- | Optional predetermined outputs to override generated outputs
     extendFileOutputs :: Maybe [PredeterminedOutput]
   }
@@ -635,9 +635,9 @@ instance FromJSON ExtendFile where
     outputs <- v Aeson..:? "outputs"
     pure
       ExtendFile
-        { extendFileFileName = fileName,
-          extendFileFileUrl = fileUrl,
-          extendFileFileId = fileId,
+        { extendFileName = fileName,
+          extendFileUrl = fileUrl,
+          extendFileId = fileId,
           extendFileOutputs = outputs
         }
 
@@ -645,9 +645,9 @@ instance ToJSON ExtendFile where
   toJSON ExtendFile {..} =
     Aeson.object $
       catMaybes
-        [ ("fileName" .=) <$> extendFileFileName,
-          ("fileUrl" .=) <$> extendFileFileUrl,
-          ("fileId" .=) <$> extendFileFileId,
+        [ ("fileName" .=) <$> extendFileName,
+          ("fileUrl" .=) <$> extendFileUrl,
+          ("fileId" .=) <$> extendFileId,
           ("outputs" .=) <$> extendFileOutputs
         ]
 


### PR DESCRIPTION
This pull request refactors the `ExtendFile` data structure by renaming several fields for improved clarity and consistency. The changes propagate through related code to ensure compatibility.

### Refactoring of `ExtendFile` data structure:

* Renamed fields in the `ExtendFile` data type in `src/Extend/V1/Workflows.hs`:
  - `extendFileFileName` → `extendFileName`
  - `extendFileFileUrl` → `extendFileUrl`
  - `extendFileFileId` → `extendFileId`

* Updated the `FromJSON` and `ToJSON` instances for `ExtendFile` to reflect the new field names in `src/Extend/V1/Workflows.hs`.

* Adjusted field references in the `runCommand` function in `extend-example/Main.hs` to align with the renamed fields.