### PR TITLE
docs: fix package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add the package to your dependencies:
 
 ```cabal
 build-depends:
-    extend
+    extend-ai
 ```
 
 ## Usage


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file to correct the package name in the `build-depends` section of the Cabal configuration. The package name was updated from `extend` to `extend-ai`.