### PR TITLE
test: add tests for get workflow run by ID and list workflow runs request / response serialization

### DIFF
--- a/extend.cabal
+++ b/extend.cabal
@@ -72,6 +72,8 @@ test-suite tasty
                     , servant-client
                     , http-client
                     , http-client-tls
+                    , time
+                    , bytestring
     ghc-options:      -Wall
 
 executable extend-example

--- a/extend.cabal
+++ b/extend.cabal
@@ -73,7 +73,6 @@ test-suite tasty
                     , http-client
                     , http-client-tls
                     , time
-                    , bytestring
     ghc-options:      -Wall
 
 executable extend-example

--- a/tasty/Main.hs
+++ b/tasty/Main.hs
@@ -23,8 +23,8 @@ tests =
         let token = ApiToken "test-token"
          in unApiToken token @?= "test-token",
       testCase "ApiVersion construction" $
-        let version = ApiVersion "2025-04-21"
-         in unApiVersion version @?= "2025-04-21",
+        let apiVersion = ApiVersion "2025-04-21"
+         in unApiVersion apiVersion @?= "2025-04-21",
       testCase "defaultApiVersion" $
         unApiVersion defaultApiVersion @?= "2025-04-21",
       testGroup
@@ -110,6 +110,93 @@ tests =
                       W.workflowRunRejectionNote = Nothing
                     }
                 response = W.GetWorkflowRunResponse True workflowRun
+                json = toJSON response
+             in case fromJSON json of
+                  Success r -> r @?= response
+                  Error err -> assertFailure $ "Round trip failed: " ++ err
+        ],
+      testGroup
+        "ListWorkflowRunsResponse"
+        [ testCase "Basic response deserialization" $
+            let json =
+                  Aeson.object
+                    [ "success" .= True,
+                      "workflowRuns"
+                        .= [ Aeson.object
+                               [ "id" .= ("workflow_run_1" :: Text),
+                                 "status" .= ("PROCESSED" :: Text),
+                                 "workflowId" .= ("workflow_test" :: Text),
+                                 "workflowName" .= ("Test Workflow" :: Text),
+                                 "workflowVersionId" .= ("workflow_version_test" :: Text),
+                                 "createdAt" .= ("2025-04-28T17:01:39.285Z" :: Text),
+                                 "updatedAt" .= ("2025-04-28T17:01:39.285Z" :: Text),
+                                 "reviewed" .= False
+                               ]
+                           ],
+                      "nextPageToken" .= ("next_page_token_test" :: Text)
+                    ]
+             in case fromJSON json of
+                  Success r -> do
+                    W.listWorkflowRunsResponseSuccess r @?= True
+                    let workflowRuns = W.listWorkflowRunsResponseWorkflowRuns r
+                    length workflowRuns @?= 1
+                    case workflowRuns of
+                      (summary : _) -> do
+                        W.workflowRunSummaryId summary @?= "workflow_run_1"
+                        W.workflowRunSummaryStatus summary @?= W.Processed
+                        W.workflowRunSummaryWorkflowId summary @?= "workflow_test"
+                      [] -> assertFailure "Expected at least one workflow run"
+                    W.listWorkflowRunsResponseNextPageToken r @?= Just "next_page_token_test"
+                  Error err -> assertFailure $ "Failed to parse: " ++ err,
+          testCase "Response with no nextPageToken deserialization" $
+            let json =
+                  Aeson.object
+                    [ "success" .= True,
+                      "workflowRuns"
+                        .= [ Aeson.object
+                               [ "id" .= ("workflow_run_1" :: Text),
+                                 "status" .= ("PROCESSED" :: Text),
+                                 "workflowId" .= ("workflow_test" :: Text),
+                                 "workflowName" .= ("Test Workflow" :: Text),
+                                 "workflowVersionId" .= ("workflow_version_test" :: Text),
+                                 "createdAt" .= ("2025-04-28T17:01:39.285Z" :: Text),
+                                 "updatedAt" .= ("2025-04-28T17:01:39.285Z" :: Text),
+                                 "reviewed" .= False
+                               ]
+                           ]
+                    ]
+             in case fromJSON json of
+                  Success r -> do
+                    W.listWorkflowRunsResponseSuccess r @?= True
+                    length (W.listWorkflowRunsResponseWorkflowRuns r) @?= 1
+                    W.listWorkflowRunsResponseNextPageToken r @?= Nothing
+                  Error err -> assertFailure $ "Failed to parse: " ++ err,
+          testCase "Response serialization/deserialization round trip" $
+            let testTime = UTCTime (ModifiedJulianDay 59000) (secondsToDiffTime 0)
+                workflowRunSummary =
+                  W.WorkflowRunSummary
+                    { W.workflowRunSummaryId = "workflow_run_summary_test",
+                      W.workflowRunSummaryStatus = W.Processed,
+                      W.workflowRunSummaryInitialRunAt = Just testTime,
+                      W.workflowRunSummaryReviewed = False,
+                      W.workflowRunSummaryStartTime = Just testTime,
+                      W.workflowRunSummaryWorkflowId = "workflow_test",
+                      W.workflowRunSummaryWorkflowName = "Test Workflow",
+                      W.workflowRunSummaryWorkflowVersionId = "workflow_version_test",
+                      W.workflowRunSummaryBatchId = Just "batch_test",
+                      W.workflowRunSummaryCreatedAt = testTime,
+                      W.workflowRunSummaryUpdatedAt = testTime,
+                      W.workflowRunSummaryName = Just "Test Workflow Run",
+                      W.workflowRunSummaryUrl = Just "https://example.com/workflow_run",
+                      W.workflowRunSummaryEndTime = Just testTime,
+                      W.workflowRunSummaryFiles = Nothing
+                    }
+                response =
+                  W.ListWorkflowRunsResponse
+                    { W.listWorkflowRunsResponseSuccess = True,
+                      W.listWorkflowRunsResponseWorkflowRuns = [workflowRunSummary],
+                      W.listWorkflowRunsResponseNextPageToken = Just "next_page_token_test"
+                    }
                 json = toJSON response
              in case fromJSON json of
                   Success r -> r @?= response

--- a/tasty/Main.hs
+++ b/tasty/Main.hs
@@ -3,7 +3,11 @@
 module Main (main) where
 
 import Data.Aeson (Result (Error, Success), fromJSON, toJSON)
+import qualified Data.Aeson as Aeson
+import Data.ByteString.Lazy.Char8 (pack)
 import Data.Text (Text)
+import Data.Time.Calendar (Day (..))
+import Data.Time.Clock (UTCTime (..), secondsToDiffTime)
 import Extend.V1
 import qualified Extend.V1.Workflows as W
 import Test.Tasty
@@ -41,17 +45,68 @@ tests =
         "RunWorkflowRequest"
         [ testCase "Basic request serialization" $
             let request =
-                  RunWorkflowRequest
+                  W.RunWorkflowRequest
                     "wf_test" -- workflowId
                     Nothing -- files
                     Nothing -- rawTexts
                     Nothing -- priority
                     Nothing -- metadata
+                    Nothing -- version
                 json = toJSON request
              in case fromJSON json of
                   Success r ->
-                    let RunWorkflowRequest wfId _ _ _ _ = r
+                    let W.RunWorkflowRequest wfId _ _ _ _ _ = r
                      in wfId @?= "wf_test"
                   Error err -> assertFailure $ "Failed to parse: " ++ err
+        ],
+      testGroup
+        "GetWorkflowRunResponse"
+        [ testCase "Basic response deserialization" $
+            let jsonStr = "{\"success\":true,\"workflowRun\":{\"object\":\"workflow_run\",\"id\":\"workflow_run_test\",\"status\":\"PROCESSED\",\"reviewed\":false}}"
+                mValue = Aeson.decode (pack jsonStr)
+             in case mValue of
+                  Nothing -> assertFailure "Failed to decode JSON string"
+                  Just value -> case fromJSON value of
+                    Success r ->
+                      do
+                        W.getWorkflowRunResponseSuccess r @?= True
+                        W.workflowRunId (W.getWorkflowRunResponseWorkflowRun r) @?= "workflow_run_test"
+                        W.workflowRunStatus (W.getWorkflowRunResponseWorkflowRun r) @?= W.Processed
+                    Error err -> assertFailure $ "Failed to parse: " ++ err,
+          testCase "Response serialization/deserialization round trip" $
+            let testTime = UTCTime (ModifiedJulianDay 59000) (secondsToDiffTime 0)
+                workflowRun =
+                  W.WorkflowRun
+                    { W.workflowRunObject = WorkflowRunObject,
+                      W.workflowRunId = "workflow_run_test",
+                      W.workflowRunName = Just "Test Workflow Run",
+                      W.workflowRunUrl = Just "https://example.com/workflow_run",
+                      W.workflowRunStatus = W.Processed,
+                      W.workflowRunMetadata = Nothing,
+                      W.workflowRunFiles = Nothing,
+                      W.workflowRunWorkflowId = Just "workflow_test",
+                      W.workflowRunWorkflowName = Just "Test Workflow",
+                      W.workflowRunWorkflowVersionId = Just "workflow_version_test",
+                      W.workflowRunCreatedAt = Just testTime,
+                      W.workflowRunUpdatedAt = Just testTime,
+                      W.workflowRunInitialRunAt = Just testTime,
+                      W.workflowRunReviewed = False,
+                      W.workflowRunReviewedBy = Nothing,
+                      W.workflowRunReviewedAt = Nothing,
+                      W.workflowRunStartTime = Just testTime,
+                      W.workflowRunEndTime = Just testTime,
+                      W.workflowRunOutputs = Nothing,
+                      W.workflowRunStepRuns = Nothing,
+                      W.workflowRunWorkflow = Nothing,
+                      W.workflowRunBatchId = Nothing,
+                      W.workflowRunFailureReason = Nothing,
+                      W.workflowRunFailureMessage = Nothing,
+                      W.workflowRunRejectionNote = Nothing
+                    }
+                response = W.GetWorkflowRunResponse True workflowRun
+                json = toJSON response
+             in case fromJSON json of
+                  Success r -> r @?= response
+                  Error err -> assertFailure $ "Round trip failed: " ++ err
         ]
     ]


### PR DESCRIPTION
This pull request adds new test cases for workflow-related data structures and updates existing ones to improve coverage and correctness. It also introduces new imports to support these changes and makes a minor update to the `extend.cabal` file to include the `time` library.

### Test Enhancements and Additions:

* **New test cases for `GetWorkflowRunResponse`:**
  - Added tests for basic deserialization, response serialization/deserialization round trips, and validation of fields such as `workflowRunId` and `workflowRunStatus`.
  
* **New test cases for `ListWorkflowRunsResponse`:**
  - Added tests for basic deserialization, handling of responses with and without `nextPageToken`, and serialization/deserialization round trips.

* **Updates to existing test cases:**
  - Updated `RunWorkflowRequest` test to use the qualified name `W.RunWorkflowRequest` for clarity.
  - Renamed variable `version` to `apiVersion` in the `ApiVersion` test for consistency.

### Dependency Updates:

* Added the `time` library to the `extend.cabal` file to support tests involving `UTCTime` and `Day`.

### Codebase Maintenance:

* Added new imports in `tasty/Main.hs` for `Data.Time.Calendar`, `Data.Time.Clock`, and additional `Data.Aeson` utilities to support the new test cases.