### PR TITLE
feat(api): add support for Bulk Workflow creation

### DIFF
--- a/extend.cabal
+++ b/extend.cabal
@@ -88,5 +88,4 @@ executable extend-example
                     , http-client-tls
                     , optparse-applicative
                     , bytestring
-                    , containers
     ghc-options:      -Wall 


### PR DESCRIPTION
This pull request introduces a new feature for batch processing workflows and includes updates to the CLI, API, and test suite. The most significant changes involve adding support for batch workflow runs, updating the CLI parser, and extending the API to handle batch requests and responses. Below is a breakdown of the changes:

### New Feature: Batch Workflow Runs

* Added a new `BatchRunWorkflow` command to the CLI, allowing users to run multiple workflows in a batch. This includes support for specifying file URLs, local file paths, optional filenames, and workflow versions. (`extend-example/Main.hs`: [[1]](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2R25) [[2]](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2R47-R58) [[3]](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2R199-R239)
* Implemented the `batchRunWorkflowCmd` function to handle batch workflow requests and responses, including logging and validation for inputs. (`extend-example/Main.hs`: [extend-example/Main.hsR404-R420](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2R404-R420))

### API Enhancements

* Added new data types (`BatchInputFile`, `BatchWorkflowInput`, `BatchRunWorkflowRequest`, `BatchRunWorkflowResponse`) to represent batch workflow inputs and outputs. These types include support for file metadata, raw text, and optional secrets. (`src/Extend/V1/Workflows.hs`: [[1]](diffhunk://#diff-3000953cb7918994ae41fbc1171b19c54a4849811675f68b6537e92606e7ade2R1055-R1181) [[2]](diffhunk://#diff-3000953cb7918994ae41fbc1171b19c54a4849811675f68b6537e92606e7ade2R1195-R1200)
* Updated the `WorkflowsAPI` type and client functions to include the `batchRunWorkflow` endpoint. (`src/Extend/V1/Workflows.hs`: [[1]](diffhunk://#diff-3000953cb7918994ae41fbc1171b19c54a4849811675f68b6537e92606e7ade2R38) [[2]](diffhunk://#diff-3000953cb7918994ae41fbc1171b19c54a4849811675f68b6537e92606e7ade2R1223-R1226) [[3]](diffhunk://#diff-3000953cb7918994ae41fbc1171b19c54a4849811675f68b6537e92606e7ade2R1246-R1253)

### CLI and Code Refinements

* Renamed the `command` variable to `cliCommand` for clarity and consistency in the main function. (`extend-example/Main.hs`: [[1]](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2L118-R131) [[2]](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2L136-R150)
* Updated the `printWorkflowRun` and `printWorkflowRunSummary` functions to display batch IDs if available. (`extend-example/Main.hs`: [[1]](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2R347-R351) [[2]](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2R380-R384)

### Test Suite Additions

* Added unit tests for `BatchRunWorkflowRequest` and `BatchRunWorkflowResponse`, covering serialization, deserialization, and round-trip validation. (`tasty/Main.hs`: [tasty/Main.hsR204-R279](diffhunk://#diff-53f70320300326aec6b7461872ca37d3b23c4bb06774ac5745cf109054a5c7edR204-R279))

### Miscellaneous Changes

* Removed an unused dependency (`containers`) from the `extend.cabal` file. (`extend.cabal`: [extend.cabalL91](diffhunk://#diff-8ecf87b1ca9a9cabb8e387cf3bf95d8b48c0011a37b33f59ded0e6769ae8886cL91))
* Minor cleanup in imports for the test suite. (`tasty/Main.hs`: [tasty/Main.hsL6-R6](diffhunk://#diff-53f70320300326aec6b7461872ca37d3b23c4bb06774ac5745cf109054a5c7edL6-R6))