### PR TITLE
[EFF-415] feat(api): add support for the Processor APIs

### DIFF
--- a/src/Extend/V1.hs
+++ b/src/Extend/V1.hs
@@ -37,19 +37,33 @@ module Extend.V1
     -- Processors
     Processor (..),
     ProcessorConfig (..),
+    ProcessorType (..),
     ProcessorRun (..),
     ProcessorRunStatus,
-    GetProcessorResponse (..),
-    ListProcessorsResponse (..),
+    ProcessorVersion (..),
+    ProcessorRunFileInput (..),
+    Extend.V1.Processors.MergedProcessor (..),
     RunProcessorRequest (..),
     RunProcessorResponse (..),
     GetProcessorRunResponse (..),
-    ListProcessorRunsResponse (..),
-    getProcessor,
-    listProcessors,
+    CreateProcessorRequest (..),
+    CreateProcessorResponse (..),
+    UpdateProcessorRequest (..),
+    UpdateProcessorResponse (..),
+    GetProcessorVersionResponse (..),
+    ListProcessorVersionsResponse (..),
+    PublishProcessorVersionRequest (..),
+    PublishProcessorVersionResponse (..),
+    BatchProcessorRun (..),
+    GetBatchProcessorRunResponse (..),
     runProcessor,
     getProcessorRun,
-    listProcessorRuns,
+    createProcessor,
+    updateProcessor,
+    getProcessorVersion,
+    listProcessorVersions,
+    publishProcessorVersion,
+    getBatchProcessorRun,
     -- Error and Common
     module Extend.V1.Error,
     module Extend.V1.Common,
@@ -63,7 +77,7 @@ import Extend.Prelude
 import Extend.V1.Common
 import Extend.V1.Error
 import Extend.V1.Files
-import Extend.V1.Processors hiding (Failed, Pending, Processed, Processing)
+import Extend.V1.Processors
 import Extend.V1.Workflows
 import qualified Network.HTTP.Client as HTTP
 import qualified Network.HTTP.Client.TLS as TLS

--- a/src/Extend/V1/Common.hs
+++ b/src/Extend/V1/Common.hs
@@ -19,6 +19,8 @@ data ObjectType
   | FileObject
   | ProcessorObject
   | ProcessorRunObject
+  | DocumentProcessorObject
+  | DocumentProcessorVersionObject
   | DocumentProcessorRunObject
   | WorkflowStepRunObject
   | WorkflowStepObject
@@ -31,6 +33,8 @@ instance FromJSON ObjectType where
     "file" -> pure FileObject
     "processor" -> pure ProcessorObject
     "processor_run" -> pure ProcessorRunObject
+    "document_processor" -> pure DocumentProcessorObject
+    "document_processor_version" -> pure DocumentProcessorVersionObject
     "document_processor_run" -> pure DocumentProcessorRunObject
     "workflow_step_run" -> pure WorkflowStepRunObject
     "workflow_step" -> pure WorkflowStepObject
@@ -43,6 +47,8 @@ instance ToJSON ObjectType where
     FileObject -> String "file"
     ProcessorObject -> String "processor"
     ProcessorRunObject -> String "processor_run"
+    DocumentProcessorObject -> String "document_processor"
+    DocumentProcessorVersionObject -> String "document_processor_version"
     DocumentProcessorRunObject -> String "document_processor_run"
     WorkflowStepRunObject -> String "workflow_step_run"
     WorkflowStepObject -> String "workflow_step"

--- a/src/Extend/V1/Common.hs
+++ b/src/Extend/V1/Common.hs
@@ -24,6 +24,7 @@ data ObjectType
   | DocumentProcessorRunObject
   | WorkflowStepRunObject
   | WorkflowStepObject
+  | BatchProcessorRunObject
   deriving stock (Show, Eq, Generic)
 
 instance FromJSON ObjectType where
@@ -38,6 +39,7 @@ instance FromJSON ObjectType where
     "document_processor_run" -> pure DocumentProcessorRunObject
     "workflow_step_run" -> pure WorkflowStepRunObject
     "workflow_step" -> pure WorkflowStepObject
+    "batch_processor_run" -> pure BatchProcessorRunObject
     _ -> fail "Unknown object type"
 
 instance ToJSON ObjectType where
@@ -52,6 +54,7 @@ instance ToJSON ObjectType where
     DocumentProcessorRunObject -> String "document_processor_run"
     WorkflowStepRunObject -> String "workflow_step_run"
     WorkflowStepObject -> String "workflow_step"
+    BatchProcessorRunObject -> String "batch_processor_run"
 
 -- | Generic success response
 data SuccessResponse a = SuccessResponse

--- a/src/Extend/V1/Processors.hs
+++ b/src/Extend/V1/Processors.hs
@@ -1,27 +1,46 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
 -- | Processor operations for the Extend API
 module Extend.V1.Processors
   ( -- * Types
     Processor (..),
     ProcessorConfig (..),
+    ProcessorType (..),
     ProcessorRun (..),
     ProcessorRunStatus (..),
+    ProcessorVersion (..),
+    ProcessorRunFileInput (..),
+    MergedProcessor (..),
     GetProcessorResponse (..),
-    ListProcessorsResponse (..),
     RunProcessorRequest (..),
     RunProcessorResponse (..),
     GetProcessorRunResponse (..),
-    ListProcessorRunsResponse (..),
+    BatchProcessorRun (..),
+    GetBatchProcessorRunResponse (..),
+    CreateProcessorRequest (..),
+    CreateProcessorResponse (..),
+    UpdateProcessorRequest (..),
+    UpdateProcessorResponse (..),
+    GetProcessorVersionResponse (..),
+    ListProcessorVersionsResponse (..),
+    PublishProcessorVersionRequest (..),
+    PublishProcessorVersionResponse (..),
 
     -- * API
     ProcessorsAPI,
-    getProcessor,
-    listProcessors,
     runProcessor,
     getProcessorRun,
-    listProcessorRuns,
+    createProcessor,
+    updateProcessor,
+    getProcessorVersion,
+    listProcessorVersions,
+    publishProcessorVersion,
+    getBatchProcessorRun,
   )
 where
 
+import Data.Aeson ((.!=))
 import qualified Data.Aeson as Aeson
 import Data.Proxy (Proxy (..))
 import Extend.Prelude
@@ -41,24 +60,42 @@ instance FromJSON ProcessorConfig where
 instance ToJSON ProcessorConfig where
   toJSON (ProcessorConfig value) = value
 
+-- | Type of processor
+data ProcessorType
+  = Extract
+  | Classify
+  | Splitter
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON ProcessorType where
+  parseJSON = Aeson.withText "ProcessorType" $ \case
+    "EXTRACT" -> pure Extract
+    "CLASSIFY" -> pure Classify
+    "SPLITTER" -> pure Splitter
+    _ -> fail "Unknown processor type"
+
+instance ToJSON ProcessorType where
+  toJSON = \case
+    Extract -> String "EXTRACT"
+    Classify -> String "CLASSIFY"
+    Splitter -> String "SPLITTER"
+
 -- | A processor in the Extend API
 data Processor = Processor
   { -- | Type of the object
-    object :: ObjectType,
+    processorObject :: ObjectType,
     -- | ID of the processor
-    id :: Text,
+    processorId :: Text,
     -- | Name of the processor
-    name :: Text,
-    -- | Description of the processor
-    description :: Maybe Text,
-    -- | Version of the processor
-    version :: Text,
-    -- | Configuration for the processor
-    config :: ProcessorConfig,
+    processorName :: Text,
+    -- | Type of the processor
+    processorType :: ProcessorType,
     -- | When the processor was created
-    createdAt :: UTCTime,
+    processorCreatedAt :: UTCTime,
     -- | When the processor was last updated
-    updatedAt :: UTCTime
+    processorUpdatedAt :: UTCTime,
+    -- | Draft version of the processor
+    processorDraftVersion :: Maybe ProcessorVersion
   }
   deriving stock (Show, Eq, Generic)
 
@@ -67,48 +104,110 @@ instance FromJSON Processor where
     objectType <- v .: "object"
     id <- v .: "id"
     name <- v .: "name"
-    description <- v .:? "description"
-    version <- v .: "version"
-    config <- v .: "config"
+    processorType <- v .: "type"
     createdAt <- v .: "createdAt"
     updatedAt <- v .: "updatedAt"
+    draftVersion <- v .:? "draftVersion"
     pure
       Processor
-        { object = objectType,
-          id = id,
-          name = name,
-          description = description,
-          version = version,
-          config = config,
-          createdAt = createdAt,
-          updatedAt = updatedAt
+        { processorObject = objectType,
+          processorId = id,
+          processorName = name,
+          processorType = processorType,
+          processorCreatedAt = createdAt,
+          processorUpdatedAt = updatedAt,
+          processorDraftVersion = draftVersion
         }
 
 instance ToJSON Processor where
   toJSON Processor {..} =
     Aeson.object $
       catMaybes
-        [ Just ("object" .= object),
-          Just ("id" .= id),
-          Just ("name" .= name),
-          ("description" .=) <$> description,
-          Just ("version" .= version),
-          Just ("config" .= config),
-          Just ("createdAt" .= createdAt),
-          Just ("updatedAt" .= updatedAt)
+        [ Just ("object" .= processorObject),
+          Just ("id" .= processorId),
+          Just ("name" .= processorName),
+          Just ("type" .= processorType),
+          Just ("createdAt" .= processorCreatedAt),
+          Just ("updatedAt" .= processorUpdatedAt),
+          ("draftVersion" .=) <$> processorDraftVersion
+        ]
+
+-- | A processor version
+data ProcessorVersion = ProcessorVersion
+  { -- | Type of the object
+    processorVersionObject :: ObjectType,
+    -- | ID of the processor version
+    processorVersionId :: Text,
+    -- | ID of the processor
+    processorVersionProcessorId :: Text,
+    -- | Name of the processor
+    processorVersionProcessorName :: Maybe Text,
+    -- | Type of the processor
+    processorVersionProcessorType :: ProcessorType,
+    -- | Description of the processor version
+    processorVersionDescription :: Maybe Text,
+    -- | Version of the processor
+    processorVersionVersion :: Text,
+    -- | Configuration for the processor
+    processorVersionConfig :: ProcessorConfig,
+    -- | When the processor version was created
+    processorVersionCreatedAt :: UTCTime,
+    -- | When the processor version was last updated
+    processorVersionUpdatedAt :: UTCTime
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON ProcessorVersion where
+  parseJSON = withObject "ProcessorVersion" $ \v -> do
+    objectType <- v .: "object"
+    id <- v .: "id"
+    processorId <- v .: "processorId"
+    processorName <- v .:? "processorName"
+    processorType <- v .: "processorType"
+    description <- v .:? "description"
+    version <- v .: "version"
+    config <- v .: "config"
+    createdAt <- v .: "createdAt"
+    updatedAt <- v .: "updatedAt"
+    pure
+      ProcessorVersion
+        { processorVersionObject = objectType,
+          processorVersionId = id,
+          processorVersionProcessorId = processorId,
+          processorVersionProcessorName = processorName,
+          processorVersionProcessorType = processorType,
+          processorVersionDescription = description,
+          processorVersionVersion = version,
+          processorVersionConfig = config,
+          processorVersionCreatedAt = createdAt,
+          processorVersionUpdatedAt = updatedAt
+        }
+
+instance ToJSON ProcessorVersion where
+  toJSON ProcessorVersion {..} =
+    Aeson.object $
+      catMaybes
+        [ Just ("object" .= processorVersionObject),
+          Just ("id" .= processorVersionId),
+          Just ("processorId" .= processorVersionProcessorId),
+          ("processorName" .=) <$> processorVersionProcessorName,
+          Just ("processorType" .= processorVersionProcessorType),
+          ("description" .=) <$> processorVersionDescription,
+          Just ("version" .= processorVersionVersion),
+          Just ("config" .= processorVersionConfig),
+          Just ("createdAt" .= processorVersionCreatedAt),
+          Just ("updatedAt" .= processorVersionUpdatedAt)
         ]
 
 -- | Status of a processor run
 data ProcessorRunStatus
-  = Pending
-  | Processing
+  = Processing
   | Processed
   | Failed
   deriving stock (Show, Eq, Generic)
 
 instance FromJSON ProcessorRunStatus where
   parseJSON = Aeson.withText "ProcessorRunStatus" $ \case
-    "PENDING" -> pure Pending
     "PROCESSING" -> pure Processing
     "PROCESSED" -> pure Processed
     "FAILED" -> pure Failed
@@ -116,39 +215,83 @@ instance FromJSON ProcessorRunStatus where
 
 instance ToJSON ProcessorRunStatus where
   toJSON = \case
-    Pending -> String "PENDING"
     Processing -> String "PROCESSING"
     Processed -> String "PROCESSED"
     Failed -> String "FAILED"
 
+-- | A merged processor reference in processor run outputs
+data MergedProcessor = MergedProcessor
+  { -- | ID of the processor
+    mergedProcessorProcessorId :: Text,
+    -- | ID of the processor version
+    mergedProcessorProcessorVersionId :: Text,
+    -- | Name of the processor
+    mergedProcessorProcessorName :: Text
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON MergedProcessor where
+  parseJSON = Aeson.withObject "MergedProcessor" $ \v -> do
+    processorId <- v Aeson..: "processorId"
+    processorVersionId <- v Aeson..: "processorVersionId"
+    processorName <- v Aeson..: "processorName"
+    pure
+      MergedProcessor
+        { mergedProcessorProcessorId = processorId,
+          mergedProcessorProcessorVersionId = processorVersionId,
+          mergedProcessorProcessorName = processorName
+        }
+
+instance ToJSON MergedProcessor where
+  toJSON MergedProcessor {..} =
+    Aeson.object
+      [ "processorId" .= mergedProcessorProcessorId,
+        "processorVersionId" .= mergedProcessorProcessorVersionId,
+        "processorName" .= mergedProcessorProcessorName
+      ]
+
 -- | A processor run in the Extend API
 data ProcessorRun = ProcessorRun
   { -- | Type of the object
-    object :: ObjectType,
+    processorRunObject :: ObjectType,
     -- | ID of the processor run
-    id :: Text,
+    processorRunId :: Text,
     -- | ID of the processor
-    processorId :: Text,
+    processorRunProcessorId :: Text,
     -- | ID of the processor version
-    processorVersionId :: Text,
+    processorRunProcessorVersionId :: Text,
     -- | Name of the processor
-    processorName :: Text,
+    processorRunProcessorName :: Text,
     -- | Status of the processor run
-    status :: ProcessorRunStatus,
-    -- | Configuration for the processor
-    config :: ProcessorConfig,
+    processorRunStatus :: ProcessorRunStatus,
     -- | Output from the processor
-    output :: Value,
-    -- | Files processed
-    files :: [File],
-    -- | When the processor run was created
-    createdAt :: UTCTime,
-    -- | When the processor run was last updated
-    updatedAt :: UTCTime,
+    processorRunOutput :: Value,
     -- | Reason for failure if failed
-    failureReason :: Maybe Text,
+    processorRunFailureReason :: Maybe Text,
     -- | Detailed failure message if failed
-    failureMessage :: Maybe Text
+    processorRunFailureMessage :: Maybe Text,
+    -- | Metadata for the processor run
+    processorRunMetadata :: Maybe Value,
+    -- | Whether the run has been reviewed
+    processorRunReviewed :: Bool,
+    -- | Whether the run has been edited
+    processorRunEdited :: Bool,
+    -- | Edits made to the output
+    processorRunEdits :: Value,
+    -- | Type of processor
+    processorRunType :: Maybe Text,
+    -- | Configuration for the processor
+    processorRunConfig :: ProcessorConfig,
+    -- | Initial output from the processor
+    processorRunInitialOutput :: Maybe Value,
+    -- | Reviewed output from the processor
+    processorRunReviewedOutput :: Maybe Value,
+    -- | Files processed
+    processorRunFiles :: [File],
+    -- | Merged processors
+    processorRunMergedProcessors :: [MergedProcessor],
+    -- | Dashboard URL for the processor run
+    processorRunUrl :: Maybe Text
   }
   deriving stock (Show, Eq, Generic)
 
@@ -160,82 +303,137 @@ instance FromJSON ProcessorRun where
     processorVersionId <- v .: "processorVersionId"
     processorName <- v .: "processorName"
     status <- v .: "status"
-    config <- v .: "config"
     output <- v .: "output"
-    files <- v .: "files"
-    createdAt <- v .: "createdAt"
-    updatedAt <- v .: "updatedAt"
     failureReason <- v .:? "failureReason"
     failureMessage <- v .:? "failureMessage"
+    metadata <- v .:? "metadata"
+    reviewed <- v .: "reviewed"
+    edited <- v .: "edited"
+    edits <- v .: "edits"
+    type_ <- v .:? "type"
+    config <- v .: "config"
+    initialOutput <- v .:? "initialOutput"
+    reviewedOutput <- v .:? "reviewedOutput"
+    files <- v .: "files"
+    mergedProcessors <- v .:? "mergedProcessors" .!= []
+    url <- v .:? "url"
     pure
       ProcessorRun
-        { object = objectType,
-          id = id,
-          processorId = processorId,
-          processorVersionId = processorVersionId,
-          processorName = processorName,
-          status = status,
-          config = config,
-          output = output,
-          files = files,
-          createdAt = createdAt,
-          updatedAt = updatedAt,
-          failureReason = failureReason,
-          failureMessage = failureMessage
+        { processorRunObject = objectType,
+          processorRunId = id,
+          processorRunProcessorId = processorId,
+          processorRunProcessorVersionId = processorVersionId,
+          processorRunProcessorName = processorName,
+          processorRunStatus = status,
+          processorRunOutput = output,
+          processorRunFailureReason = failureReason,
+          processorRunFailureMessage = failureMessage,
+          processorRunMetadata = metadata,
+          processorRunReviewed = reviewed,
+          processorRunEdited = edited,
+          processorRunEdits = edits,
+          processorRunType = type_,
+          processorRunConfig = config,
+          processorRunInitialOutput = initialOutput,
+          processorRunReviewedOutput = reviewedOutput,
+          processorRunFiles = files,
+          processorRunMergedProcessors = mergedProcessors,
+          processorRunUrl = url
         }
 
 instance ToJSON ProcessorRun where
   toJSON ProcessorRun {..} =
     Aeson.object $
       catMaybes
-        [ Just ("object" .= object),
-          Just ("id" .= id),
-          Just ("processorId" .= processorId),
-          Just ("processorVersionId" .= processorVersionId),
-          Just ("processorName" .= processorName),
-          Just ("status" .= status),
-          Just ("config" .= config),
-          Just ("output" .= output),
-          Just ("files" .= files),
-          Just ("createdAt" .= createdAt),
-          Just ("updatedAt" .= updatedAt),
-          ("failureReason" .=) <$> failureReason,
-          ("failureMessage" .=) <$> failureMessage
+        [ Just ("object" .= processorRunObject),
+          Just ("id" .= processorRunId),
+          Just ("processorId" .= processorRunProcessorId),
+          Just ("processorVersionId" .= processorRunProcessorVersionId),
+          Just ("processorName" .= processorRunProcessorName),
+          Just ("status" .= processorRunStatus),
+          Just ("output" .= processorRunOutput),
+          ("failureReason" .=) <$> processorRunFailureReason,
+          ("failureMessage" .=) <$> processorRunFailureMessage,
+          ("metadata" .=) <$> processorRunMetadata,
+          Just ("reviewed" .= processorRunReviewed),
+          Just ("edited" .= processorRunEdited),
+          Just ("edits" .= processorRunEdits),
+          ("type" .=) <$> processorRunType,
+          Just ("config" .= processorRunConfig),
+          ("initialOutput" .=) <$> processorRunInitialOutput,
+          ("reviewedOutput" .=) <$> processorRunReviewedOutput,
+          Just ("files" .= processorRunFiles),
+          Just ("mergedProcessors" .= processorRunMergedProcessors),
+          ("url" .=) <$> processorRunUrl
+        ]
+
+-- | File to process through a processor
+data ProcessorRunFileInput = ProcessorRunFileInput
+  { -- | The name of the file to be processed
+    processorRunFileInputFileName :: Maybe Text,
+    -- | A URL where the file can be downloaded from
+    processorRunFileInputFileUrl :: Maybe Text,
+    -- | Extend's internal ID for the file
+    processorRunFileInputFileId :: Maybe Text
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON ProcessorRunFileInput where
+  parseJSON = Aeson.withObject "ProcessorRunFileInput" $ \v -> do
+    fileName <- v Aeson..:? "fileName"
+    fileUrl <- v Aeson..:? "fileUrl"
+    fileId <- v Aeson..:? "fileId"
+    pure
+      ProcessorRunFileInput
+        { processorRunFileInputFileName = fileName,
+          processorRunFileInputFileUrl = fileUrl,
+          processorRunFileInputFileId = fileId
+        }
+
+instance ToJSON ProcessorRunFileInput where
+  toJSON ProcessorRunFileInput {..} =
+    Aeson.object $
+      catMaybes
+        [ ("fileName" .=) <$> processorRunFileInputFileName,
+          ("fileUrl" .=) <$> processorRunFileInputFileUrl,
+          ("fileId" .=) <$> processorRunFileInputFileId
         ]
 
 -- | Response from getting a processor
-newtype GetProcessorResponse = GetProcessorResponse
-  { -- | The requested processor
-    processor :: Processor
+data GetProcessorResponse = GetProcessorResponse
+  { -- | Whether the request was successful
+    getProcessorResponseSuccess :: Bool,
+    -- | The requested processor
+    getProcessorResponseProcessor :: Processor
   }
   deriving stock (Show, Eq, Generic)
 
 instance FromJSON GetProcessorResponse where
   parseJSON = withObject "GetProcessorResponse" $ \v -> do
+    success <- v .: "success"
     processor <- v .: "processor"
-    pure GetProcessorResponse {..}
-
--- | Response from listing processors
-data ListProcessorsResponse = ListProcessorsResponse
-  { -- | The processors
-    processors :: [Processor],
-    -- | Pagination information
-    pagination :: Maybe Pagination
-  }
-  deriving stock (Show, Eq, Generic)
-
-instance FromJSON ListProcessorsResponse where
-  parseJSON = withObject "ListProcessorsResponse" $ \v -> do
-    processors <- v .: "processors"
-    pagination <- v .:? "pagination"
-    pure ListProcessorsResponse {..}
+    pure
+      GetProcessorResponse
+        { getProcessorResponseSuccess = success,
+          getProcessorResponseProcessor = processor
+        }
 
 -- | Request to run a processor
 data RunProcessorRequest = RunProcessorRequest
-  { -- | IDs of the files to process
-    fileIds :: [Text],
+  { -- | The ID of the processor to run
+    runProcessorRequestProcessorId :: Text,
+    -- | Optional version of the processor to use
+    runProcessorRequestVersion :: Maybe Text,
+    -- | Optional file to process
+    runProcessorRequestFile :: Maybe ProcessorRunFileInput,
+    -- | Optional raw text to process
+    runProcessorRequestRawText :: Maybe Text,
+    -- | Optional priority
+    runProcessorRequestPriority :: Maybe Int,
+    -- | Optional metadata
+    runProcessorRequestMetadata :: Maybe Value,
     -- | Optional configuration overrides
-    config :: Maybe ProcessorConfig
+    runProcessorRequestConfig :: Maybe ProcessorConfig
   }
   deriving stock (Show, Eq, Generic)
 
@@ -243,127 +441,435 @@ instance ToJSON RunProcessorRequest where
   toJSON RunProcessorRequest {..} =
     Aeson.object $
       catMaybes
-        [ Just ("fileIds" .= fileIds),
-          ("config" .=) <$> config
+        [ Just ("processorId" .= runProcessorRequestProcessorId),
+          ("version" .=) <$> runProcessorRequestVersion,
+          ("file" .=) <$> runProcessorRequestFile,
+          ("rawText" .=) <$> runProcessorRequestRawText,
+          ("priority" .=) <$> runProcessorRequestPriority,
+          ("metadata" .=) <$> runProcessorRequestMetadata,
+          ("config" .=) <$> runProcessorRequestConfig
         ]
 
+instance FromJSON RunProcessorRequest where
+  parseJSON = Aeson.withObject "RunProcessorRequest" $ \v -> do
+    processorId <- v Aeson..: "processorId"
+    version <- v Aeson..:? "version"
+    file <- v Aeson..:? "file"
+    rawText <- v Aeson..:? "rawText"
+    priority <- v Aeson..:? "priority"
+    metadata <- v Aeson..:? "metadata"
+    config <- v Aeson..:? "config"
+    pure
+      RunProcessorRequest
+        { runProcessorRequestProcessorId = processorId,
+          runProcessorRequestVersion = version,
+          runProcessorRequestFile = file,
+          runProcessorRequestRawText = rawText,
+          runProcessorRequestPriority = priority,
+          runProcessorRequestMetadata = metadata,
+          runProcessorRequestConfig = config
+        }
+
 -- | Response from running a processor
-newtype RunProcessorResponse = RunProcessorResponse
-  { -- | The created processor run
-    processorRun :: ProcessorRun
+data RunProcessorResponse = RunProcessorResponse
+  { -- | Whether the request was successful
+    runProcessorResponseSuccess :: Bool,
+    -- | The created processor run
+    runProcessorResponseProcessorRun :: ProcessorRun
   }
   deriving stock (Show, Eq, Generic)
 
 instance FromJSON RunProcessorResponse where
   parseJSON = withObject "RunProcessorResponse" $ \v -> do
+    success <- v .: "success"
     processorRun <- v .: "processorRun"
-    pure RunProcessorResponse {..}
+    pure
+      RunProcessorResponse
+        { runProcessorResponseSuccess = success,
+          runProcessorResponseProcessorRun = processorRun
+        }
 
 -- | Response from getting a processor run
-newtype GetProcessorRunResponse = GetProcessorRunResponse
-  { -- | The requested processor run
-    processorRun :: ProcessorRun
+data GetProcessorRunResponse = GetProcessorRunResponse
+  { -- | Whether the request was successful
+    getProcessorRunResponseSuccess :: Bool,
+    -- | The requested processor run
+    getProcessorRunResponseProcessorRun :: ProcessorRun
   }
   deriving stock (Show, Eq, Generic)
 
 instance FromJSON GetProcessorRunResponse where
   parseJSON = withObject "GetProcessorRunResponse" $ \v -> do
+    success <- v .: "success"
     processorRun <- v .: "processorRun"
-    pure GetProcessorRunResponse {..}
+    pure
+      GetProcessorRunResponse
+        { getProcessorRunResponseSuccess = success,
+          getProcessorRunResponseProcessorRun = processorRun
+        }
 
--- | Response from listing processor runs
-data ListProcessorRunsResponse = ListProcessorRunsResponse
-  { -- | The processor runs
-    processorRuns :: [ProcessorRun],
-    -- | Pagination information
-    pagination :: Maybe Pagination
+-- | A batch processor run
+data BatchProcessorRun = BatchProcessorRun
+  { -- | Type of the object
+    batchProcessorRunObject :: ObjectType,
+    -- | ID of the batch processor run
+    batchProcessorRunId :: Text,
+    -- | ID of the processor
+    batchProcessorRunProcessorId :: Text,
+    -- | ID of the processor version
+    batchProcessorRunProcessorVersionId :: Text,
+    -- | Name of the processor
+    batchProcessorRunProcessorName :: Text,
+    -- | Metrics for the batch run
+    batchProcessorRunMetrics :: Value,
+    -- | Status of the batch processor run
+    batchProcessorRunStatus :: Text,
+    -- | Source of the batch processor run
+    batchProcessorRunSource :: Text,
+    -- | ID of the source
+    batchProcessorRunSourceId :: Maybe Text,
+    -- | Number of runs
+    batchProcessorRunRunCount :: Int,
+    -- | Options for the batch processor run
+    batchProcessorRunOptions :: Value,
+    -- | When the batch processor run was created
+    batchProcessorRunCreatedAt :: UTCTime,
+    -- | When the batch processor run was last updated
+    batchProcessorRunUpdatedAt :: UTCTime
   }
   deriving stock (Show, Eq, Generic)
 
-instance FromJSON ListProcessorRunsResponse where
-  parseJSON = withObject "ListProcessorRunsResponse" $ \v -> do
-    processorRuns <- v .: "processorRuns"
-    pagination <- v .:? "pagination"
-    pure ListProcessorRunsResponse {..}
+instance FromJSON BatchProcessorRun where
+  parseJSON = withObject "BatchProcessorRun" $ \v -> do
+    objectType <- v .: "object"
+    id <- v .: "id"
+    processorId <- v .: "processorId"
+    processorVersionId <- v .: "processorVersionId"
+    processorName <- v .: "processorName"
+    metrics <- v .: "metrics"
+    status <- v .: "status"
+    source <- v .: "source"
+    sourceId <- v .:? "sourceId"
+    runCount <- v .: "runCount"
+    options <- v .: "options"
+    createdAt <- v .: "createdAt"
+    updatedAt <- v .: "updatedAt"
+    pure
+      BatchProcessorRun
+        { batchProcessorRunObject = objectType,
+          batchProcessorRunId = id,
+          batchProcessorRunProcessorId = processorId,
+          batchProcessorRunProcessorVersionId = processorVersionId,
+          batchProcessorRunProcessorName = processorName,
+          batchProcessorRunMetrics = metrics,
+          batchProcessorRunStatus = status,
+          batchProcessorRunSource = source,
+          batchProcessorRunSourceId = sourceId,
+          batchProcessorRunRunCount = runCount,
+          batchProcessorRunOptions = options,
+          batchProcessorRunCreatedAt = createdAt,
+          batchProcessorRunUpdatedAt = updatedAt
+        }
+
+instance ToJSON BatchProcessorRun where
+  toJSON BatchProcessorRun {..} =
+    Aeson.object $
+      catMaybes
+        [ Just ("object" .= batchProcessorRunObject),
+          Just ("id" .= batchProcessorRunId),
+          Just ("processorId" .= batchProcessorRunProcessorId),
+          Just ("processorVersionId" .= batchProcessorRunProcessorVersionId),
+          Just ("processorName" .= batchProcessorRunProcessorName),
+          Just ("metrics" .= batchProcessorRunMetrics),
+          Just ("status" .= batchProcessorRunStatus),
+          Just ("source" .= batchProcessorRunSource),
+          ("sourceId" .=) <$> batchProcessorRunSourceId,
+          Just ("runCount" .= batchProcessorRunRunCount),
+          Just ("options" .= batchProcessorRunOptions),
+          Just ("createdAt" .= batchProcessorRunCreatedAt),
+          Just ("updatedAt" .= batchProcessorRunUpdatedAt)
+        ]
+
+-- | Response from getting a batch processor run
+data GetBatchProcessorRunResponse = GetBatchProcessorRunResponse
+  { -- | Whether the request was successful
+    getBatchProcessorRunResponseSuccess :: Bool,
+    -- | The requested batch processor run
+    getBatchProcessorRunResponseBatchProcessorRun :: BatchProcessorRun
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON GetBatchProcessorRunResponse where
+  parseJSON = withObject "GetBatchProcessorRunResponse" $ \v -> do
+    success <- v .: "success"
+    batchProcessorRun <- v .: "batchProcessorRun"
+    pure
+      GetBatchProcessorRunResponse
+        { getBatchProcessorRunResponseSuccess = success,
+          getBatchProcessorRunResponseBatchProcessorRun = batchProcessorRun
+        }
+
+-- | Request to create a processor
+data CreateProcessorRequest = CreateProcessorRequest
+  { -- | The name of the processor
+    createProcessorRequestName :: Text,
+    -- | The type of the processor
+    createProcessorRequestType :: ProcessorType,
+    -- | The ID of an existing processor to clone
+    createProcessorRequestCloneProcessorId :: Maybe Text,
+    -- | Configuration for the processor
+    createProcessorRequestConfig :: Maybe ProcessorConfig
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance ToJSON CreateProcessorRequest where
+  toJSON CreateProcessorRequest {..} =
+    Aeson.object $
+      catMaybes
+        [ Just ("name" .= createProcessorRequestName),
+          Just ("type" .= createProcessorRequestType),
+          ("cloneProcessorId" .=) <$> createProcessorRequestCloneProcessorId,
+          ("config" .=) <$> createProcessorRequestConfig
+        ]
+
+instance FromJSON CreateProcessorRequest where
+  parseJSON = Aeson.withObject "CreateProcessorRequest" $ \v -> do
+    name <- v Aeson..: "name"
+    type_ <- v Aeson..: "type"
+    cloneProcessorId <- v Aeson..:? "cloneProcessorId"
+    config <- v Aeson..:? "config"
+    pure
+      CreateProcessorRequest
+        { createProcessorRequestName = name,
+          createProcessorRequestType = type_,
+          createProcessorRequestCloneProcessorId = cloneProcessorId,
+          createProcessorRequestConfig = config
+        }
+
+-- | Response from creating a processor
+data CreateProcessorResponse = CreateProcessorResponse
+  { -- | Whether the request was successful
+    createProcessorResponseSuccess :: Bool,
+    -- | The created processor
+    createProcessorResponseProcessor :: Processor
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON CreateProcessorResponse where
+  parseJSON = withObject "CreateProcessorResponse" $ \v -> do
+    success <- v .: "success"
+    processor <- v .: "processor"
+    pure
+      CreateProcessorResponse
+        { createProcessorResponseSuccess = success,
+          createProcessorResponseProcessor = processor
+        }
+
+-- | Request to update a processor
+data UpdateProcessorRequest = UpdateProcessorRequest
+  { -- | The name of the processor
+    updateProcessorRequestName :: Maybe Text,
+    -- | Configuration for the processor
+    updateProcessorRequestConfig :: Maybe ProcessorConfig
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance ToJSON UpdateProcessorRequest where
+  toJSON UpdateProcessorRequest {..} =
+    Aeson.object $
+      catMaybes
+        [ ("name" .=) <$> updateProcessorRequestName,
+          ("config" .=) <$> updateProcessorRequestConfig
+        ]
+
+instance FromJSON UpdateProcessorRequest where
+  parseJSON = Aeson.withObject "UpdateProcessorRequest" $ \v -> do
+    name <- v Aeson..:? "name"
+    config <- v Aeson..:? "config"
+    pure
+      UpdateProcessorRequest
+        { updateProcessorRequestName = name,
+          updateProcessorRequestConfig = config
+        }
+
+-- | Response from updating a processor
+data UpdateProcessorResponse = UpdateProcessorResponse
+  { -- | Whether the request was successful
+    updateProcessorResponseSuccess :: Bool,
+    -- | The updated processor
+    updateProcessorResponseProcessor :: Processor
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON UpdateProcessorResponse where
+  parseJSON = withObject "UpdateProcessorResponse" $ \v -> do
+    success <- v .: "success"
+    processor <- v .: "processor"
+    pure
+      UpdateProcessorResponse
+        { updateProcessorResponseSuccess = success,
+          updateProcessorResponseProcessor = processor
+        }
+
+-- | Response from getting a processor version
+data GetProcessorVersionResponse = GetProcessorVersionResponse
+  { -- | Whether the request was successful
+    getProcessorVersionResponseSuccess :: Bool,
+    -- | The requested processor version
+    getProcessorVersionResponseVersion :: ProcessorVersion
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON GetProcessorVersionResponse where
+  parseJSON = withObject "GetProcessorVersionResponse" $ \v -> do
+    success <- v .: "success"
+    version <- v .: "version"
+    pure
+      GetProcessorVersionResponse
+        { getProcessorVersionResponseSuccess = success,
+          getProcessorVersionResponseVersion = version
+        }
+
+-- | Response from listing processor versions
+data ListProcessorVersionsResponse = ListProcessorVersionsResponse
+  { -- | Whether the request was successful
+    listProcessorVersionsResponseSuccess :: Bool,
+    -- | The processor versions
+    listProcessorVersionsResponseVersions :: [ProcessorVersion]
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON ListProcessorVersionsResponse where
+  parseJSON = withObject "ListProcessorVersionsResponse" $ \v -> do
+    success <- v .: "success"
+    versions <- v .: "versions"
+    pure
+      ListProcessorVersionsResponse
+        { listProcessorVersionsResponseSuccess = success,
+          listProcessorVersionsResponseVersions = versions
+        }
+
+-- | Request to publish a processor version
+data PublishProcessorVersionRequest = PublishProcessorVersionRequest
+  { -- | The type of release for this version
+    publishProcessorVersionRequestReleaseType :: Text,
+    -- | Description of the changes in this version
+    publishProcessorVersionRequestDescription :: Maybe Text,
+    -- | Configuration for this version of the processor
+    publishProcessorVersionRequestConfig :: Maybe ProcessorConfig
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance ToJSON PublishProcessorVersionRequest where
+  toJSON PublishProcessorVersionRequest {..} =
+    Aeson.object $
+      catMaybes
+        [ Just ("releaseType" .= publishProcessorVersionRequestReleaseType),
+          ("description" .=) <$> publishProcessorVersionRequestDescription,
+          ("config" .=) <$> publishProcessorVersionRequestConfig
+        ]
+
+instance FromJSON PublishProcessorVersionRequest where
+  parseJSON = Aeson.withObject "PublishProcessorVersionRequest" $ \v -> do
+    releaseType <- v Aeson..: "releaseType"
+    description <- v Aeson..:? "description"
+    config <- v Aeson..:? "config"
+    pure
+      PublishProcessorVersionRequest
+        { publishProcessorVersionRequestReleaseType = releaseType,
+          publishProcessorVersionRequestDescription = description,
+          publishProcessorVersionRequestConfig = config
+        }
+
+-- | Response from publishing a processor version
+data PublishProcessorVersionResponse = PublishProcessorVersionResponse
+  { -- | Whether the request was successful
+    publishProcessorVersionResponseSuccess :: Bool,
+    -- | The published processor version
+    publishProcessorVersionResponseProcessorVersion :: ProcessorVersion
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance FromJSON PublishProcessorVersionResponse where
+  parseJSON = withObject "PublishProcessorVersionResponse" $ \v -> do
+    success <- v .: "success"
+    processorVersion <- v .: "processorVersion"
+    pure
+      PublishProcessorVersionResponse
+        { publishProcessorVersionResponseSuccess = success,
+          publishProcessorVersionResponseProcessorVersion = processorVersion
+        }
 
 -- | Processors API endpoints
 type ProcessorsAPI =
-  "processors"
-    :> Capture "processorId" Text
-    :> Header' '[Required, Strict] "Authorization" Text
-    :> Header' '[Required, Strict] "x-extend-api-version" Text
-    :> Get '[JSON] (SuccessResponse GetProcessorResponse)
-    :<|> "processors"
-    :> Header' '[Required, Strict] "Authorization" Text
-    :> Header' '[Required, Strict] "x-extend-api-version" Text
-    :> QueryParam "limit" Int
-    :> QueryParam "page" Int
-    :> Get '[JSON] (SuccessResponse ListProcessorsResponse)
-    :<|> "processors"
-    :> Capture "processorId" Text
-    :> "runs"
+  "processor_runs"
     :> Header' '[Required, Strict] "Authorization" Text
     :> Header' '[Required, Strict] "x-extend-api-version" Text
     :> ReqBody '[JSON] RunProcessorRequest
-    :> Post '[JSON] (SuccessResponse RunProcessorResponse)
-    :<|> "processors"
-    :> "runs"
-    :> Capture "runId" Text
+    :> Post '[JSON] RunProcessorResponse
+    :<|> "processor_runs"
+    :> Capture "id" Text
     :> Header' '[Required, Strict] "Authorization" Text
     :> Header' '[Required, Strict] "x-extend-api-version" Text
-    :> Get '[JSON] (SuccessResponse GetProcessorRunResponse)
+    :> Get '[JSON] GetProcessorRunResponse
     :<|> "processors"
-    :> Capture "processorId" Text
-    :> "runs"
     :> Header' '[Required, Strict] "Authorization" Text
     :> Header' '[Required, Strict] "x-extend-api-version" Text
-    :> QueryParam "limit" Int
-    :> QueryParam "page" Int
-    :> Get '[JSON] (SuccessResponse ListProcessorRunsResponse)
+    :> ReqBody '[JSON] CreateProcessorRequest
+    :> Post '[JSON] CreateProcessorResponse
+    :<|> "processors"
+    :> Capture "id" Text
+    :> Header' '[Required, Strict] "Authorization" Text
+    :> Header' '[Required, Strict] "x-extend-api-version" Text
+    :> ReqBody '[JSON] UpdateProcessorRequest
+    :> Post '[JSON] UpdateProcessorResponse
+    :<|> "processors"
+    :> Capture "id" Text
+    :> "versions"
+    :> Capture "processorVersionId" Text
+    :> Header' '[Required, Strict] "Authorization" Text
+    :> Header' '[Required, Strict] "x-extend-api-version" Text
+    :> Get '[JSON] GetProcessorVersionResponse
+    :<|> "processors"
+    :> Capture "id" Text
+    :> "versions"
+    :> Header' '[Required, Strict] "Authorization" Text
+    :> Header' '[Required, Strict] "x-extend-api-version" Text
+    :> Get '[JSON] ListProcessorVersionsResponse
+    :<|> "processors"
+    :> Capture "id" Text
+    :> "publish"
+    :> Header' '[Required, Strict] "Authorization" Text
+    :> Header' '[Required, Strict] "x-extend-api-version" Text
+    :> ReqBody '[JSON] PublishProcessorVersionRequest
+    :> Post '[JSON] PublishProcessorVersionResponse
+    :<|> "batch_processor_runs"
+    :> Capture "id" Text
+    :> Header' '[Required, Strict] "Authorization" Text
+    :> Header' '[Required, Strict] "x-extend-api-version" Text
+    :> Get '[JSON] GetBatchProcessorRunResponse
 
 -- | Split the client functions for easier access
 processorsAPI :: Proxy ProcessorsAPI
 processorsAPI = Proxy
 
-getProcessorClient :: Text -> Text -> Text -> ClientM (SuccessResponse GetProcessorResponse)
-listProcessorsClient :: Text -> Text -> Maybe Int -> Maybe Int -> ClientM (SuccessResponse ListProcessorsResponse)
-runProcessorClient :: Text -> Text -> Text -> RunProcessorRequest -> ClientM (SuccessResponse RunProcessorResponse)
-getProcessorRunClient :: Text -> Text -> Text -> ClientM (SuccessResponse GetProcessorRunResponse)
-listProcessorRunsClient :: Text -> Text -> Text -> Maybe Int -> Maybe Int -> ClientM (SuccessResponse ListProcessorRunsResponse)
-getProcessorClient :<|> listProcessorsClient :<|> runProcessorClient :<|> getProcessorRunClient :<|> listProcessorRunsClient = client processorsAPI
-
--- | Get a processor
-getProcessor ::
-  ApiToken ->
-  ApiVersion ->
-  -- | Processor ID
-  Text ->
-  ClientM (SuccessResponse GetProcessorResponse)
-getProcessor (ApiToken token) (ApiVersion version) processorId =
-  getProcessorClient processorId ("Bearer " <> token) version
-
--- | List processors
-listProcessors ::
-  ApiToken ->
-  ApiVersion ->
-  -- | Limit
-  Maybe Int ->
-  -- | Page
-  Maybe Int ->
-  ClientM (SuccessResponse ListProcessorsResponse)
-listProcessors (ApiToken token) (ApiVersion version) limit page =
-  listProcessorsClient ("Bearer " <> token) version limit page
+runProcessorClient :: Text -> Text -> RunProcessorRequest -> ClientM RunProcessorResponse
+getProcessorRunClient :: Text -> Text -> Text -> ClientM GetProcessorRunResponse
+createProcessorClient :: Text -> Text -> CreateProcessorRequest -> ClientM CreateProcessorResponse
+updateProcessorClient :: Text -> Text -> Text -> UpdateProcessorRequest -> ClientM UpdateProcessorResponse
+getProcessorVersionClient :: Text -> Text -> Text -> Text -> ClientM GetProcessorVersionResponse
+listProcessorVersionsClient :: Text -> Text -> Text -> ClientM ListProcessorVersionsResponse
+publishProcessorVersionClient :: Text -> Text -> Text -> PublishProcessorVersionRequest -> ClientM PublishProcessorVersionResponse
+getBatchProcessorRunClient :: Text -> Text -> Text -> ClientM GetBatchProcessorRunResponse
+runProcessorClient :<|> getProcessorRunClient :<|> createProcessorClient :<|> updateProcessorClient :<|> getProcessorVersionClient :<|> listProcessorVersionsClient :<|> publishProcessorVersionClient :<|> getBatchProcessorRunClient = client processorsAPI
 
 -- | Run a processor
 runProcessor ::
   ApiToken ->
   ApiVersion ->
-  -- | Processor ID
-  Text ->
   RunProcessorRequest ->
-  ClientM (SuccessResponse RunProcessorResponse)
-runProcessor (ApiToken token) (ApiVersion version) processorId req =
-  runProcessorClient processorId ("Bearer " <> token) version req
+  ClientM RunProcessorResponse
+runProcessor (ApiToken token) (ApiVersion version) = runProcessorClient ("Bearer " <> token) version
 
 -- | Get a processor run
 getProcessorRun ::
@@ -371,20 +877,69 @@ getProcessorRun ::
   ApiVersion ->
   -- | Run ID
   Text ->
-  ClientM (SuccessResponse GetProcessorRunResponse)
+  ClientM GetProcessorRunResponse
 getProcessorRun (ApiToken token) (ApiVersion version) runId =
   getProcessorRunClient runId ("Bearer " <> token) version
 
--- | List processor runs
-listProcessorRuns ::
+-- | Create a processor
+createProcessor ::
+  ApiToken ->
+  ApiVersion ->
+  CreateProcessorRequest ->
+  ClientM CreateProcessorResponse
+createProcessor (ApiToken token) (ApiVersion version) = createProcessorClient ("Bearer " <> token) version
+
+-- | Update a processor
+updateProcessor ::
   ApiToken ->
   ApiVersion ->
   -- | Processor ID
   Text ->
-  -- | Limit
-  Maybe Int ->
-  -- | Page
-  Maybe Int ->
-  ClientM (SuccessResponse ListProcessorRunsResponse)
-listProcessorRuns (ApiToken token) (ApiVersion version) processorId limit page =
-  listProcessorRunsClient processorId ("Bearer " <> token) version limit page
+  UpdateProcessorRequest ->
+  ClientM UpdateProcessorResponse
+updateProcessor (ApiToken token) (ApiVersion version) processorId = updateProcessorClient processorId ("Bearer " <> token) version
+
+-- | Get a processor version
+getProcessorVersion ::
+  ApiToken ->
+  ApiVersion ->
+  -- | Processor ID
+  Text ->
+  -- | Processor version ID
+  Text ->
+  ClientM GetProcessorVersionResponse
+getProcessorVersion (ApiToken token) (ApiVersion version) processorId processorVersionId =
+  getProcessorVersionClient processorId processorVersionId ("Bearer " <> token) version
+
+-- | List processor versions
+listProcessorVersions ::
+  ApiToken ->
+  ApiVersion ->
+  -- | Processor ID
+  Text ->
+  ClientM ListProcessorVersionsResponse
+listProcessorVersions (ApiToken token) (ApiVersion version) processorId =
+  listProcessorVersionsClient processorId ("Bearer " <> token) version
+
+-- | Publish a processor version
+publishProcessorVersion ::
+  ApiToken ->
+  ApiVersion ->
+  -- | Processor ID
+  Text ->
+  PublishProcessorVersionRequest ->
+  ClientM PublishProcessorVersionResponse
+publishProcessorVersion (ApiToken token) (ApiVersion version) processorId = publishProcessorVersionClient processorId ("Bearer " <> token) version
+
+-- | Get a batch processor run
+getBatchProcessorRun ::
+  ApiToken ->
+  ApiVersion ->
+  -- | Batch processor run ID
+  Text ->
+  ClientM GetBatchProcessorRunResponse
+getBatchProcessorRun (ApiToken token) (ApiVersion version) batchProcessorRunId =
+  getBatchProcessorRunClient
+    batchProcessorRunId
+    ("Bearer " <> token)
+    version


### PR DESCRIPTION
This pull request introduces significant enhancements to the `extend-example` project by adding support for processor-related commands and functionality. The changes include extending the CLI to manage processors, implementing processor-related API commands, and updating the data model to accommodate new processor-related object types.

### CLI Enhancements:
* Added new commands to the CLI for managing processors, including creating, updating, running, and publishing processors, as well as retrieving processor runs, versions, and batch processor runs. (`extend-example/Main.hs`) [[1]](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2R30-R37) [[2]](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2R94-R159)

### Processor API Integration:
* Implemented API commands for processor operations, such as `runProcessorCmd`, `createProcessorCmd`, `updateProcessorCmd`, and others, to interact with the backend. These commands handle requests and responses for processor-related actions. (`extend-example/Main.hs`) [[1]](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2R415-R498) [[2]](diffhunk://#diff-3581db3417a67c221d4baf26dc01bc57517ea7c932ee96642b0b7d37ddeecef2R673-R842)

### Argument Parsing:
* Introduced new argument parsers for processor commands, including `processorIdArg`, `fileArg`, `processorNameArg`, and others, to support the extended CLI functionality. (`extend-example/Main.hs`)

### Data Model Updates:
* Added new object types to the `ObjectType` data model, such as `DocumentProcessorObject`, `DocumentProcessorVersionObject`, and `BatchProcessorRunObject`, along with corresponding JSON serialization and deserialization support. (`src/Extend/V1/Common.hs`) [[1]](diffhunk://#diff-30123c8c30a020412850cfe568fb9ca47b98db4f34aad3c896053a84df786829R22-R27) [[2]](diffhunk://#diff-30123c8c30a020412850cfe568fb9ca47b98db4f34aad3c896053a84df786829R37-R42) [[3]](diffhunk://#diff-30123c8c30a020412850cfe568fb9ca47b98db4f34aad3c896053a84df786829R52-R57)

### Library Updates:
* Updated the `Extend.V1` module to include new processor-related types and functions, such as `CreateProcessorRequest`, `RunProcessorRequest`, and `PublishProcessorVersionRequest`. (`src/Extend/V1.hs`) [[1]](diffhunk://#diff-38c3d1dd8778cf45dadf80d63f6081ac1c6c7e4da9d47215216c8b903219f5b2R40-R66) [[2]](diffhunk://#diff-38c3d1dd8778cf45dadf80d63f6081ac1c6c7e4da9d47215216c8b903219f5b2L66-R80)

### Testing
<details><summary>Details</summary>
<p>

```sh
cabal run extend-example -- create-processor "My Test Processor 2" EXTRACT

cabal run extend-example -- run-processor dp_u-Ey8REzc13M_6vHZosFj https://www.irs.gov/pub/irs-pdf/f1040.pdf
Running processor: dp_u-Ey8REzc13M_6vHZosFj
File: https://www.irs.gov/pub/irs-pdf/f1040.pdf
Success: True
  - ID: dpr_4oAMu7QPywYGUNMDEe57Z
    Processor ID: dp_u-Ey8REzc13M_6vHZosFj
    Processor Name: My Test Processor 2
    Status: Processing
    Type: EXTRACT
    URL: https://dashboard.extend.ai/runs/dpr_4oAMu7QPywYGUNMDEe57Z
    Reviewed: False
    Edited: False
    Files: 1

cabal run extend-example -- get-processor-run dpr_4vVILrO3PzO4wGZB94xl6
Getting processor run: dpr_4vVILrO3PzO4wGZB94xl6
Success: True
  - ID: dpr_4vVILrO3PzO4wGZB94xl6
    Processor ID: dp_u-Ey8REzc13M_6vHZosFj
    Processor Name: My Test Processor 2
    Status: Processed
    Type: EXTRACT
    URL: https://dashboard.extend.ai/runs/dpr_4vVILrO3PzO4wGZB94xl6
    Reviewed: False
    Edited: False
    Files: 1

cabal run extend-example -- list-processor-versions dp_u-Ey8REzc13M_6vHZosFj
Listing processor versions: dp_u-Ey8REzc13M_6vHZosFj
Success: True
Found 1 processor versions:
  - ID: dpv_BAHF-7QgUGP8f7nHATSXj
    Processor ID: dp_u-Ey8REzc13M_6vHZosFj
    Version: draft
    Type: Extract
    Created At: 2025-05-15 16:36:57.915 UTC
    Updated At: 2025-05-15 16:36:57.915 UTC

cabal run extend-example -- get-processor-version dp_u-Ey8REzc13M_6vHZosFj dpv_BAHF-7QgUGP8f7nHATSXj
Getting processor version: dp_u-Ey8REzc13M_6vHZosFj
Version ID: dpv_BAHF-7QgUGP8f7nHATSXj
Success: True
  - ID: dpv_BAHF-7QgUGP8f7nHATSXj
    Processor ID: dp_u-Ey8REzc13M_6vHZosFj
    Processor Name: My Test Processor 2
    Version: draft
    Type: Extract
    Created At: 2025-05-15 16:36:57.915 UTC
    Updated At: 2025-05-15 16:36:57.915 UTC

cabal run extend-example -- publish-processor-version dp_u-Ey8REzc13M_6vHZosFj minor
Publishing processor version: dp_u-Ey8REzc13M_6vHZosFj
Release type: minor
Success: True
  - ID: dpv_vswbQMvUHAnuDlM8JcJI0
    Processor ID: dp_u-Ey8REzc13M_6vHZosFj
    Version: 0.1
    Type: Extract
    Created At: 2025-05-15 17:29:00.424 UTC
    Updated At: 2025-05-15 17:29:00.424 UTC
```

</p>
</details> 